### PR TITLE
Possible testing error fix

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -12,6 +12,9 @@
  * @type {Object}
  */
 const config = {
+  moduleNameMapper: {
+    '^dexie$': require.resolve('dexie'),
+  },
   // Specify that the test environment should have a DOM.
   // This is important for testing a web app that runs in a browser.
   testEnvironment: 'jsdom',


### PR DESCRIPTION
## Description
When running tests that used `dexie`, we were running into an issue similar to:
```js
    export { Dexie$1 as Dexie, RangeSet, Dexie$1 as default, liveQuery, mergeRanges, rangesOverlap };
    ^^^^^^

    SyntaxError: Unexpected token 'export'
```

This seemed to have been solved by adding
```js
  moduleNameMapper: {
    '^dexie$': require.resolve('dexie'),
  },
```
to the `jest.config.js` file